### PR TITLE
Correctly handle polling

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
@@ -52,46 +52,46 @@ abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel imple
 
     abstract Channel newChildChannel(int fd) throws Exception;
 
-    boolean acceptComplete(int res) {
-        if (res >= 0) {
-            final IOUringRecvByteAllocatorHandle allocHandle =
-                    (IOUringRecvByteAllocatorHandle) unsafe()
-                            .recvBufAllocHandle();
-            final ChannelPipeline pipeline = pipeline();
-
-            allocHandle.incMessagesRead(1);
-            try {
-                final Channel childChannel = newChildChannel(res);
-                pipeline.fireChannelRead(childChannel);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            allocHandle.readComplete();
-            pipeline.fireChannelReadComplete();
-        }
-        //Todo refactoring method name
-        executeReadEvent();
-        return res >= 0;
-    }
-
     final class UringServerChannelUnsafe extends AbstractIOUringChannel.AbstractUringUnsafe {
         private final byte[] acceptedAddress = new byte[26];
 
+
+        @Override
+        void scheduleRead() {
+            IOUringSubmissionQueue submissionQueue = submissionQueue();
+            //Todo get network addresses
+            submissionQueue.addAccept(fd().intValue());
+            submissionQueue.submit();
+        }
+
+        void readComplete0(int res) {
+            if (res >= 0) {
+                final IOUringRecvByteAllocatorHandle allocHandle =
+                        (IOUringRecvByteAllocatorHandle) unsafe()
+                                .recvBufAllocHandle();
+                final ChannelPipeline pipeline = pipeline();
+
+                allocHandle.incMessagesRead(1);
+                try {
+                    final Channel childChannel = newChildChannel(res);
+
+                    // all childChannels should poll POLLRDHUP
+                    IOUringSubmissionQueue submissionQueue = submissionQueue();
+                    submissionQueue.addPollRdHup(res);
+                    submissionQueue.submit();
+
+                    pipeline.fireChannelRead(childChannel);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                allocHandle.readComplete();
+                pipeline.fireChannelReadComplete();
+            }
+        }
         @Override
         public void connect(final SocketAddress remoteAddress, final SocketAddress localAddress,
                             final ChannelPromise promise) {
             promise.setFailure(new UnsupportedOperationException());
-        }
-
-        @Override
-        public void uringEventExecution() {
-            final IOUringEventLoop ioUringEventLoop = (IOUringEventLoop) eventLoop();
-            IOUringSubmissionQueue submissionQueue = ioUringEventLoop.getRingBuffer().getIoUringSubmissionQueue();
-            submissionQueue.addPollLink(socket.intValue());
-
-            //Todo get network addresses
-            submissionQueue.addAccept(fd().intValue());
-            submissionQueue.submit();
         }
     }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
@@ -21,8 +21,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
-import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
 import io.netty.channel.RecvByteBufAllocator;
 import io.netty.channel.socket.DuplexChannel;
@@ -30,6 +30,7 @@ import io.netty.util.internal.UnstableApi;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.io.IOException;
 import java.util.concurrent.Executor;
 
 abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel implements DuplexChannel {
@@ -191,7 +192,7 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
         }
 
         @Override
-        public void uringEventExecution() {
+        void scheduleRead() {
             final ChannelConfig config = config();
 
             final ByteBufAllocator allocator = config.getAllocator();
@@ -201,6 +202,82 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
             ByteBuf byteBuf = allocHandle.allocate(allocator);
             doReadBytes(byteBuf);
         }
-    }
 
+        private ByteBuf readBuffer;
+
+        public void doReadBytes(ByteBuf byteBuf) {
+            assert readBuffer == null;
+            IOUringEventLoop ioUringEventLoop = (IOUringEventLoop) eventLoop();
+            IOUringSubmissionQueue submissionQueue = ioUringEventLoop.getRingBuffer().getIoUringSubmissionQueue();
+
+            unsafe().recvBufAllocHandle().attemptedBytesRead(byteBuf.writableBytes());
+
+            if (byteBuf.hasMemoryAddress()) {
+                readBuffer = byteBuf;
+                submissionQueue.addRead(socket.intValue(), byteBuf.memoryAddress(),
+                        byteBuf.writerIndex(), byteBuf.capacity());
+                submissionQueue.submit();
+            }
+        }
+
+        void readComplete0(int localReadAmount) {
+            boolean close = false;
+            ByteBuf byteBuf = null;
+            final IOUringRecvByteAllocatorHandle allocHandle =
+                    (IOUringRecvByteAllocatorHandle) unsafe()
+                            .recvBufAllocHandle();
+            final ChannelPipeline pipeline = pipeline();
+            try {
+                logger.trace("EventLoop Read Res: {}", localReadAmount);
+                logger.trace("EventLoop Fd: {}", fd().intValue());
+                byteBuf = this.readBuffer;
+                this.readBuffer = null;
+
+                if (localReadAmount > 0) {
+                    byteBuf.writerIndex(byteBuf.writerIndex() + localReadAmount);
+                }
+
+                allocHandle.lastBytesRead(localReadAmount);
+                if (allocHandle.lastBytesRead() <= 0) {
+                    // nothing was read, release the buffer.
+                    byteBuf.release();
+                    byteBuf = null;
+                    close = allocHandle.lastBytesRead() < 0;
+                    if (close) {
+                        // There is nothing left to read as we received an EOF.
+                        shutdownInput(false);
+                    }
+                    allocHandle.readComplete();
+                    pipeline.fireChannelReadComplete();
+                    return;
+                }
+
+                allocHandle.incMessagesRead(1);
+                pipeline.fireChannelRead(byteBuf);
+                byteBuf = null;
+                allocHandle.readComplete();
+                pipeline.fireChannelReadComplete();
+            } catch (Throwable t) {
+                handleReadException(pipeline, byteBuf, t, close, allocHandle);
+            }
+        }
+
+        private void handleReadException(ChannelPipeline pipeline, ByteBuf byteBuf,
+                                         Throwable cause, boolean close,
+                                         IOUringRecvByteAllocatorHandle allocHandle) {
+            if (byteBuf != null) {
+                if (byteBuf.isReadable()) {
+                    pipeline.fireChannelRead(byteBuf);
+                } else {
+                    byteBuf.release();
+                }
+            }
+            allocHandle.readComplete();
+            pipeline.fireChannelReadComplete();
+            pipeline.fireExceptionCaught(cause);
+            if (close || cause instanceof IOException) {
+                shutdownInput(false);
+            }
+        }
+    }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
@@ -28,7 +28,7 @@ final class IOUring {
     static final int OP_WRITE = 23;
     static final int OP_POLL_REMOVE = 7;
 
-    static final int POLLMASK_LINK = 1;
+    static final int POLLMASK_IN = 1;
     static final int POLLMASK_OUT = 4;
     static final int POLLMASK_RDHUP = 8192;
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -119,7 +119,7 @@ final class IOUringSubmissionQueue {
         //user_data should be same as POLL_LINK fd
         if (op == IOUring.OP_POLL_REMOVE) {
             PlatformDependent.putInt(sqe + SQE_FD_FIELD, -1);
-            long pollLinkuData = convertToUserData((byte) IOUring.IO_POLL, fd, IOUring.POLLMASK_LINK);
+            long pollLinkuData = convertToUserData((byte) IOUring.IO_POLL, fd, IOUring.POLLMASK_IN);
             PlatformDependent.putLong(sqe + SQE_ADDRESS_FIELD, pollLinkuData);
         }
 
@@ -127,7 +127,7 @@ final class IOUringSubmissionQueue {
         PlatformDependent.putLong(sqe + SQE_USER_DATA_FIELD, uData);
 
         //poll<link>read or accept operation
-        if (op == 6 && (pollMask == IOUring.POLLMASK_OUT || pollMask == IOUring.POLLMASK_LINK)) {
+        if (op == 6 && (pollMask == IOUring.POLLMASK_OUT || pollMask == IOUring.POLLMASK_IN)) {
             PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, (byte) IOSQE_IO_LINK);
         } else {
             PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, (byte) 0);
@@ -168,8 +168,8 @@ final class IOUringSubmissionQueue {
         return true;
     }
 
-    public boolean addPollLink(int fd) {
-        return addPoll(fd, IOUring.POLLMASK_LINK);
+    public boolean addPollIn(int fd) {
+        return addPoll(fd, IOUring.POLLMASK_IN);
     }
 
     public boolean addPollOut(int fd) {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -134,7 +134,7 @@ public class NativeTest {
         assertNotNull(completionQueue);
 
         final FileDescriptor eventFd = Native.newEventFd();
-        assertTrue(submissionQueue.addPollLink(eventFd.intValue()));
+        assertTrue(submissionQueue.addPollIn(eventFd.intValue()));
         submissionQueue.submit();
 
         new Thread() {
@@ -188,7 +188,7 @@ public class NativeTest {
         };
         waitingCqe.start();
         final FileDescriptor eventFd = Native.newEventFd();
-        assertTrue(submissionQueue.addPollLink(eventFd.intValue()));
+        assertTrue(submissionQueue.addPollIn(eventFd.intValue()));
         submissionQueue.submit();
 
         new Thread() {
@@ -216,7 +216,7 @@ public class NativeTest {
         final IOUringCompletionQueue completionQueue = ringBuffer.getIoUringCompletionQueue();
 
         FileDescriptor eventFd = Native.newEventFd();
-        submissionQueue.addPollLink(eventFd.intValue());
+        submissionQueue.addPollIn(eventFd.intValue());
         submissionQueue.submit();
 
         Thread.sleep(10);


### PR DESCRIPTION
Motivation:

We must correctly use the polling support of io_uring to reduce the number of events in flight + only allocate buffers if really needed. For this we should respect the different poll masks and only do the corresponding IO action once the fd becomes ready for it.

Modification:

- Correctly respect poll masks and so only schedule an IO event if the fd is ready for it
- Move some code for cleanup

Result:

More correct usage of io_uring and less memory usage