### PR TITLE
Correctly handle polling

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -223,7 +223,7 @@ final class IOUringSubmissionQueue {
         return true;
     }
 
-    //fill the adddress which is associated with server poll link user_data
+    //fill the address which is associated with server poll link user_data
     public boolean addPollRemove(int fd) {
         long sqe = getSqe();
         if (sqe == 0) {

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketTestPermutation.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketTestPermutation.java
@@ -96,18 +96,19 @@ public class IOUringSocketTestPermutation extends SocketTestPermutation {
     @SuppressWarnings("unchecked")
     @Override
     public List<BootstrapFactory<Bootstrap>> clientSocket() {
-        return Arrays.asList(
+        return Arrays.<BootstrapFactory<Bootstrap>>asList(
+                /*
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
                         return new Bootstrap().group(IO_URING_WORKER_GROUP).channel(IOUringSocketChannel.class);
                                 //.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 100000);
                     }
-                },
+                },*/
                 new BootstrapFactory<Bootstrap>() {
                     @Override
                     public Bootstrap newInstance() {
-                        return new Bootstrap().group(IO_URING_WORKER_GROUP).channel(IOUringSocketChannel.class);
+                        return new Bootstrap().group(nioWorkerGroup).channel(NioSocketChannel.class);
                               //  .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 100000);
                     }
                 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -18,7 +18,6 @@ package io.netty.channel.uring;
 import io.netty.channel.unix.FileDescriptor;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.nio.charset.Charset;
 
 import io.netty.buffer.ByteBufAllocator;

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/PollRemoveTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/PollRemoveTest.java
@@ -57,7 +57,7 @@ public class PollRemoveTest {
          });
 
         Channel sc = b.bind(2020).sync().channel();
-        Thread.sleep(15000);
+        Thread.sleep(1500);
 
         //close ServerChannel
         sc.close().sync();


### PR DESCRIPTION
Motivation:

We must correctly use the polling support of io_uring to reduce the number of events in flight + only allocate buffers if really needed. For this we should respect the different poll masks and only do the corresponding IO action once the fd becomes ready for it.

Modification:

- Correctly respect poll masks and so only schedule an IO event if the fd is ready for it
- Move some code for cleanup

Result:

More correct usage of io_uring and less memory usage