### PR TITLE
Correctly respect RecvByteBufAllocator.Handle when reading

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -34,11 +34,8 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(IOUringEventLoop.class);
 
     //Todo set config ring buffer size
-    private final int ringSize = 32;
-    private final int ENOENT = -2;
-
-    //just temporary -> Todo use ErrorsStaticallyReferencedJniMethods like in Epoll
-    private static final int SOCKET_ERROR_EPIPE = -32;
+    private static final int ringSize = 32;
+    private static final int ENOENT = -2;
     private static final long ETIME = -62;
     static final long ECANCELED = -125;
 
@@ -263,7 +260,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         try {
             eventfd.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn("Failed to close the event fd.", e);
         }
         ringBuffer.close();
         iovecArrayPool.release();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringRecvByteAllocatorHandle.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringRecvByteAllocatorHandle.java
@@ -41,9 +41,4 @@ final class IOUringRecvByteAllocatorHandle extends RecvByteBufAllocator.Delegati
     public boolean continueReading(UncheckedBooleanSupplier maybeMoreDataSupplier) {
         return ((RecvByteBufAllocator.ExtendedHandle) delegate()).continueReading(maybeMoreDataSupplier);
     }
-
-    @Override
-    public boolean continueReading() {
-        return false;
-    }
 }


### PR DESCRIPTION
Motivation:

We need to respect RecvByteBufAllocator.Handle.continueReading() so settings like MAX_MESSAGES_PER_READ are respected. This also ensures that AUTO_READ is correctly working in all cases

Modifications:

- Correctly respect continueReading();
- Fix IOUringRecvByteAllocatorHandle
- Cleanup

Result:

Correctly handling reading