### PR TITLE
Correctly handle POLLRDHUP registration in all cases

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
@@ -77,11 +77,6 @@ abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel imple
                 allocHandle.incMessagesRead(1);
                 try {
                     Channel channel = newChildChannel(res);
-                    // Register accepted channel for POLLRDHUP
-                    IOUringSubmissionQueue submissionQueue = submissionQueue();
-                    submissionQueue.addPollRdHup(res);
-                    submissionQueue.submit();
-
                     pipeline.fireChannelRead(channel);
                     if (allocHandle.continueReading()) {
                         scheduleRead();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
@@ -187,6 +187,17 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
         }
     }
 
+    @Override
+    protected void doRegister() throws Exception {
+        super.doRegister();
+        if (active) {
+            // Register for POLLRDHUP if this channel is already considered active.
+            IOUringSubmissionQueue submissionQueue = submissionQueue();
+            submissionQueue.addPollRdHup(fd().intValue());
+            submissionQueue.submit();
+        }
+    }
+
     class IOUringStreamUnsafe extends AbstractUringUnsafe {
 
         // Overridden here just to be able to access this method from AbstractEpollStreamChannel


### PR DESCRIPTION
Motivation:

When accepting a Channel we did register it for POLLRDHUP, but unfortunally we used the IOUringSubmissionQueue that is tied to the IOUringEventLoop that is used for the ServerChannel. This is not correct as the EventLoop used for the accepted Channel may be different.

Modification:

Move logic into doRegister() and so register for POLLRDHUP on the right IOURingSubmissionQueue

Result:

Correct POLLRDHUP handling
