### PR TITLE
Fix failure during accept(...)

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -56,7 +56,7 @@ import static io.netty.channel.unix.UnixChannelUtil.*;
 import static io.netty.util.internal.ObjectUtil.*;
 
 abstract class AbstractIOUringChannel extends AbstractChannel implements UnixChannel {
-    private static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractIOUringChannel.class);
+    static final InternalLogger logger = InternalLoggerFactory.getInstance(AbstractIOUringChannel.class);
     private static final ChannelMetadata METADATA = new ChannelMetadata(false);
     final LinuxSocket socket;
     protected volatile boolean active;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
@@ -29,12 +29,8 @@ import static io.netty.channel.unix.Errors.*;
 
 abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel implements ServerChannel {
 
-    AbstractIOUringServerChannel(int fd) {
-        super(null, new LinuxSocket(fd));
-    }
-
-    AbstractIOUringServerChannel(LinuxSocket fd) {
-        super(null, fd);
+    protected AbstractIOUringServerChannel(LinuxSocket socket, boolean active) {
+        super(null, socket, active);
     }
 
     @Override

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringServerSocketChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringServerSocketChannel.java
@@ -18,22 +18,15 @@ package io.netty.channel.uring;
 import io.netty.channel.Channel;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.unix.FileDescriptor;
-import io.netty.channel.unix.Socket;
 
-import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 
 public final class IOUringServerSocketChannel extends AbstractIOUringServerChannel implements ServerSocketChannel {
     private final IOUringServerSocketChannelConfig config;
-    private volatile Collection<InetAddress> tcpMd5SigAddresses = Collections.emptyList();
 
     public IOUringServerSocketChannel() {
-        super(Socket.newSocketStream().intValue());
+        super(LinuxSocket.newSocketStream(), false);
         this.config = new IOUringServerSocketChannelConfig(this);
     }
 


### PR DESCRIPTION
Motivation:

Sometimes accept failed as we not correctly set the active variable when constructing the server channel. This lead to the situation that we tried to add POLLIN before the channel become active and so tried to call accept before it was listen.

Modifications:

- Use the correct constructor
- Cleanup

Result:

No more accept failures.