### PR TITLE
Correctly handle CompositeByteBuf when using IOURING

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -276,12 +276,18 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
         if (writeScheduled) {
             return;
         }
+
         int msgCount = in.size();
-        if (msgCount > 1 && in.current() instanceof ByteBuf) {
+        if (msgCount == 0) {
+            return;
+        }
+        ByteBuf msg = (ByteBuf) in.current();
+        if (msgCount > 1 ||
+                // We also need some special handling for CompositeByteBuf
+                msg.nioBufferCount() > 1) {
             doWriteMultiple(in);
         } else if (msgCount == 1) {
-            Object msg = in.current();
-            doWriteSingle((ByteBuf) msg);
+            doWriteSingle(msg);
         }
     }
 

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringCompositeBufferGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringCompositeBufferGatheringWriteTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.CompositeBufferGatheringWriteTest;
+
+import java.util.List;
+
+public class IOUringCompositeBufferGatheringWriteTest extends CompositeBufferGatheringWriteTest  {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}


### PR DESCRIPTION
Motivation:

CompositeByteBuf need some special handling as well as we have multiple buffers wrapped that needs to be written via writev.

Modification:

Also handle ByteBuf with more then one nioBuffer special.

Result:

Writing CompositeByteBuf works