### PR TITLE
Add more tests from the testsuite for io_uring

### DIFF
--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketAutoReadTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketAutoReadTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketAutoReadTest;
+
+import java.util.List;
+
+public class IOUringSocketAutoReadTest extends SocketAutoReadTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketChannelNotYetConnectedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketChannelNotYetConnectedTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketChannelNotYetConnectedTest;
+
+import java.util.List;
+
+public class IOUringSocketChannelNotYetConnectedTest extends SocketChannelNotYetConnectedTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketCloseForciblyTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketCloseForciblyTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketCloseForciblyTest;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+
+public class IOUringSocketCloseForciblyTest extends SocketCloseForciblyTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Ignore("FIX ME")
+    @Test
+    @Override
+    public void testCloseForcibly() throws Throwable {
+        super.testCloseForcibly();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConditionalWritabilityTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConditionalWritabilityTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketConditionalWritabilityTest;
+
+import java.util.List;
+
+public class IOUringSocketConditionalWritabilityTest extends SocketConditionalWritabilityTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketConnectTest;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+
+public class IOUringSocketConnectTest extends SocketConnectTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Ignore
+    @Test
+    @Override
+    public void testLocalAddressAfterConnect() throws Throwable {
+        super.testLocalAddressAfterConnect();
+    }
+
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectionAttemptTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectionAttemptTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketConnectionAttemptTest;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+
+public class IOUringSocketConnectionAttemptTest extends SocketConnectionAttemptTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapFactory<Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.clientSocket();
+    }
+
+    @Ignore("FIX ME")
+    @Test
+    @Override
+    public void testConnectTimeout() throws Throwable {
+        super.testConnectTimeout();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketDataReadInitialStateTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketDataReadInitialStateTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketDataReadInitialStateTest;
+
+import java.util.List;
+
+public class IOUringSocketDataReadInitialStateTest extends SocketDataReadInitialStateTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketExceptionHandlingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketExceptionHandlingTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketExceptionHandlingTest;
+
+import java.util.List;
+
+public class IOUringSocketExceptionHandlingTest extends SocketExceptionHandlingTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketGatheringWriteTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketGatheringWriteTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketGatheringWriteTest;
+
+import java.util.List;
+
+public class IOUringSocketGatheringWriteTest extends SocketGatheringWriteTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketHalfClosedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketHalfClosedTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+
+public class IOUringSocketHalfClosedTest extends SocketHalfClosedTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Ignore("FIX ME")
+    @Test
+    public void testHalfClosureOnlyOneEventWhenAutoRead() throws Throwable {
+        super.testHalfClosureOnlyOneEventWhenAutoRead();
+    }
+
+
+    @Ignore("FIX ME")
+    @Test
+    public void testAutoCloseFalseDoesShutdownOutput() throws Throwable {
+        super.testAutoCloseFalseDoesShutdownOutput();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketMultipleConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketMultipleConnectTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketMultipleConnectTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IOUringSocketMultipleConnectTest extends SocketMultipleConnectTest {
+
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> factories
+                = new ArrayList<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>>();
+        for (TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap> comboFactory
+                : IOUringSocketTestPermutation.INSTANCE.socket()) {
+            EventLoopGroup group = comboFactory.newClientInstance().config().group();
+            if (group instanceof NioEventLoopGroup || group instanceof IOUringEventLoop) {
+                factories.add(comboFactory);
+            }
+        }
+        return factories;
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketReadPendingTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketReadPendingTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketReadPendingTest;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+
+public class IOUringSocketReadPendingTest extends SocketReadPendingTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Ignore("FIX ME")
+    @Test
+    @Override
+    public void testReadPendingIsResetAfterEachRead() throws Throwable {
+        super.testReadPendingIsResetAfterEachRead();
+    }
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketRstTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketRstTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.unix.Errors;
+import io.netty.testsuite.transport.TestsuitePermutation;
+import io.netty.testsuite.transport.socket.SocketRstTest;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class IOUringSocketRstTest extends SocketRstTest {
+    @Override
+    protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
+        return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Override
+    protected void assertRstOnCloseException(IOException cause, Channel clientChannel) {
+        if (!AbstractIOUringChannel.class.isInstance(clientChannel)) {
+            super.assertRstOnCloseException(cause, clientChannel);
+            return;
+        }
+
+        assertTrue("actual [type, message]: [" + cause.getClass() + ", " + cause.getMessage() + "]",
+                cause instanceof Errors.NativeIoException);
+        assertEquals(Errors.ERRNO_ECONNRESET_NEGATIVE, ((Errors.NativeIoException) cause).expectedErr());
+    }
+}


### PR DESCRIPTION
Motivation:

We need more testing for io_uring to be consistent with the others transports

Modifications:

Add more tests by extending the testsuite (still some to add) and mark failing tests as ignore. These ignored tests should be fixed one by one in followup commits

Results:

More testing