### PR TITLE
Fix bug that would case an IllegalStateException when closeForcibly()…

### DIFF
--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketCloseForciblyTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketCloseForciblyTest.java
@@ -19,8 +19,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketCloseForciblyTest;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import java.util.List;
 
@@ -28,12 +26,5 @@ public class IOUringSocketCloseForciblyTest extends SocketCloseForciblyTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();
-    }
-
-    @Ignore("FIX ME")
-    @Test
-    @Override
-    public void testCloseForcibly() throws Throwable {
-        super.testCloseForcibly();
     }
 }


### PR DESCRIPTION
… is called and the Channel is not registered yet.
