### PR TITLE
Correctly obtain localAddress after connect was complete

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -371,6 +371,9 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
             }
             active = true;
 
+            if (local == null) {
+                local = socket.localAddress();
+            }
             computeRemote();
 
             // Register POLLRDHUP

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketConnectTest.java
@@ -19,8 +19,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketConnectTest;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import java.util.List;
 
@@ -29,12 +27,4 @@ public class IOUringSocketConnectTest extends SocketConnectTest {
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();
     }
-
-    @Ignore
-    @Test
-    @Override
-    public void testLocalAddressAfterConnect() throws Throwable {
-        super.testLocalAddressAfterConnect();
-    }
-
 }


### PR DESCRIPTION
Motivation:

We need to cache the localAddress after the connect was complete

Modifications:

- Call socket.localAddress() after the connect was complete
- Enable test again

Result:

Correctly set localAddress after connect was successful
