### PR TITLE
Obtain static fields via JNI and not duplicate their values

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -218,14 +218,14 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
         if (isRegistered()) {
             IOUringSubmissionQueue submissionQueue = submissionQueue();
             if ((ioState & POLL_IN_SCHEDULED) != 0) {
-                submissionQueue.addPollRemove(socket.intValue(), IOUring.POLLMASK_IN);
+                submissionQueue.addPollRemove(socket.intValue(), Native.POLLIN);
                 ioState &= ~POLL_IN_SCHEDULED;
             }
             if ((ioState & POLL_OUT_SCHEDULED) != 0) {
-                submissionQueue.addPollRemove(socket.intValue(), IOUring.POLLMASK_OUT);
+                submissionQueue.addPollRemove(socket.intValue(), Native.POLLOUT);
                 ioState &= ~POLL_OUT_SCHEDULED;
             }
-            submissionQueue.addPollRemove(socket.intValue(), IOUring.POLLMASK_RDHUP);
+            submissionQueue.addPollRemove(socket.intValue(), Native.POLLRDHUP);
             submissionQueue.submit();
         }
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUring.java
@@ -20,18 +20,6 @@ import io.netty.util.internal.SystemPropertyUtil;
 final class IOUring {
 
     private static final Throwable UNAVAILABILITY_CAUSE;
-    static final int OP_WRITEV = 2;
-    static final int IO_POLL = 6;
-    static final int IO_TIMEOUT = 11;
-    static final int OP_ACCEPT = 13;
-    static final int OP_READ = 22;
-    static final int OP_WRITE = 23;
-    static final int OP_POLL_REMOVE = 7;
-    static final int OP_CONNECT = 16;
-
-    static final int POLLMASK_IN = 1;
-    static final int POLLMASK_OUT = 4;
-    static final int POLLMASK_RDHUP = 8192;
 
     static {
         Throwable cause = null;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -15,9 +15,7 @@
  */
 package io.netty.channel.uring;
 
-import io.netty.channel.DefaultFileRegion;
 import io.netty.channel.unix.FileDescriptor;
-import io.netty.channel.unix.PeerCredentials;
 import io.netty.channel.unix.Socket;
 import io.netty.util.internal.NativeLibraryLoader;
 import io.netty.util.internal.PlatformDependent;
@@ -30,11 +28,9 @@ import java.io.IOException;
 import java.nio.channels.Selector;
 import java.util.Locale;
 
-import static io.netty.channel.unix.Socket.isIPv6Preferred;
-
 
 final class Native {
-   private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
     private static final int DEFAULT_RING_SIZE = SystemPropertyUtil.getInt("io.netty.uring.ringSize", 32);
 
      static {
@@ -66,8 +62,20 @@ final class Native {
         }
         Socket.initialize();
     }
+    static final int SOCK_NONBLOCK = NativeStaticallyReferencedJniMethods.sockNonblock();
+    static final int SOCK_CLOEXEC = NativeStaticallyReferencedJniMethods.sockCloexec();
+    static final int POLLIN = NativeStaticallyReferencedJniMethods.pollin();
+    static final int POLLOUT = NativeStaticallyReferencedJniMethods.pollout();
+    static final int POLLRDHUP = NativeStaticallyReferencedJniMethods.pollrdhup();
 
-
+    static final int IORING_OP_POLL_ADD = NativeStaticallyReferencedJniMethods.ioringOpPollAdd();
+    static final int IORING_OP_TIMEOUT = NativeStaticallyReferencedJniMethods.ioringOpTimeout();
+    static final int IORING_OP_ACCEPT = NativeStaticallyReferencedJniMethods.ioringOpAccept();
+    static final int IORING_OP_READ = NativeStaticallyReferencedJniMethods.ioringOpRead();
+    static final int IORING_OP_WRITE = NativeStaticallyReferencedJniMethods.ioringOpWrite();
+    static final int IORING_OP_POLL_REMOVE = NativeStaticallyReferencedJniMethods.ioringOpPollRemove();
+    static final int IORING_OP_CONNECT = NativeStaticallyReferencedJniMethods.ioringOpConnect();
+    static final int IORING_OP_WRITEV = NativeStaticallyReferencedJniMethods.ioringOpWritev();
 
     public static RingBuffer createRingBuffer(int ringSize) {
         //Todo throw Exception if it's null

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.channel.uring;
+
+/**
+ * This class is necessary to break the following cyclic dependency:
+ * <ol>
+ * <li>JNI_OnLoad</li>
+ * <li>JNI Calls FindClass because RegisterNatives (used to register JNI methods) requires a class</li>
+ * <li>FindClass loads the class, but static members variables of that class attempt to call a JNI method which has not
+ * yet been registered.</li>
+ * <li>java.lang.UnsatisfiedLinkError is thrown because native method has not yet been registered.</li>
+ * </ol>
+ * Static members which call JNI methods must not be declared in this class!
+ */
+final class NativeStaticallyReferencedJniMethods {
+
+    private NativeStaticallyReferencedJniMethods() { }
+
+    static native int sockNonblock();
+    static native int sockCloexec();
+    static native int pollin();
+    static native int pollout();
+    static native int pollrdhup();
+
+    static native int ioringOpWritev();
+    static native int ioringOpPollAdd();
+    static native int ioringOpPollRemove();
+    static native int ioringOpTimeout();
+    static native int ioringOpAccept();
+    static native int ioringOpRead();
+    static native int ioringOpWrite();
+    static native int ioringOpConnect();
+}

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -229,7 +229,7 @@ public class NativeTest {
         FileDescriptor eventFd = Native.newEventFd();
         submissionQueue.addPollIn(eventFd.intValue());
         submissionQueue.submit();
-        submissionQueue.addPollRemove(eventFd.intValue(), IOUring.POLLMASK_IN);
+        submissionQueue.addPollRemove(eventFd.intValue(), Native.POLLIN);
         submissionQueue.submit();
 
         final AtomicReference<AssertionError> errorRef = new AtomicReference<AssertionError>();
@@ -238,9 +238,9 @@ public class NativeTest {
                     new IOUringCompletionQueue.IOUringCompletionQueueCallback() {
                 @Override
                 public boolean handle(int fd, int res, long flags, int op, int mask) {
-                    if (op == IOUring.IO_POLL) {
+                    if (op == Native.IORING_OP_POLL_ADD) {
                         assertEquals(IOUringEventLoop.ECANCELED, res);
-                    } else if (op == IOUring.OP_POLL_REMOVE) {
+                    } else if (op == Native.IORING_OP_POLL_REMOVE) {
                         assertEquals(0, res);
                     } else {
                         fail("op " + op);


### PR DESCRIPTION
Motivation:

To ensure we use the correct values when passing values from Java to C and the other way around it is better to use JNI to lookup the values.

Modifications:

Add NativeStaticallyRefererencedJniMethods and use it (just as we do in kqueue / epoll)

Results:

More robust code