### PR TITLE
Proposed IOUring changes

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -171,7 +171,8 @@ static jint netty_io_uring_enter(JNIEnv *env, jclass class1, jint ring_fd, jint 
 }
 
 static jint netty_epoll_native_eventFd(JNIEnv* env, jclass clazz) {
-    jint eventFD = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+    // We use a blocking fd with io_uring FAST_POLL read
+    jint eventFD = eventfd(0, EFD_CLOEXEC);
 
     if (eventFD < 0) {
         netty_unix_errors_throwChannelExceptionErrorNo(env, "eventfd() failed: ", errno);

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -226,7 +226,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
                 ioState &= ~POLL_OUT_SCHEDULED;
             }
             submissionQueue.addPollRemove(socket.intValue(), Native.POLLRDHUP);
-            submissionQueue.submit();
         }
 
         // Even if we allow half closed sockets we should give up on reading. Otherwise we may allow a read attempt on a
@@ -313,7 +312,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
 
              if (iovecArray.count() > 0) {
                  submissionQueue().addWritev(socket.intValue(), iovecMemoryAddress, iovecArray.count());
-                 submissionQueue().submit();
                  ioState |= WRITE_SCHEDULED;
              }
          } else {
@@ -324,10 +322,8 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
 
 
     protected final void doWriteSingle(ByteBuf buf) {
-        IOUringSubmissionQueue submissionQueue = submissionQueue();
-        submissionQueue.addWrite(socket.intValue(), buf.memoryAddress(), buf.readerIndex(),
+        submissionQueue().addWrite(socket.intValue(), buf.memoryAddress(), buf.readerIndex(),
                 buf.writerIndex());
-        submissionQueue.submit();
         ioState |= WRITE_SCHEDULED;
     }
 
@@ -335,9 +331,7 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
     private void addPollOut() {
         assert (ioState & POLL_OUT_SCHEDULED) == 0;
         ioState |= POLL_OUT_SCHEDULED;
-        IOUringSubmissionQueue submissionQueue = submissionQueue();
-        submissionQueue.addPollOut(socket.intValue());
-        submissionQueue.submit();
+        submissionQueue().addPollOut(socket.intValue());
     }
 
     abstract class AbstractUringUnsafe extends AbstractUnsafe {
@@ -377,9 +371,7 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
             computeRemote();
 
             // Register POLLRDHUP
-            IOUringSubmissionQueue submissionQueue = submissionQueue();
-            submissionQueue.addPollRdHup(fd().intValue());
-            submissionQueue.submit();
+            submissionQueue().addPollRdHup(fd().intValue());
 
             // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
             // We still need to ensure we call fireChannelActive() in this case.
@@ -448,9 +440,7 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
                 return;
             }
             ioState |= POLL_IN_SCHEDULED;
-            IOUringSubmissionQueue submissionQueue = submissionQueue();
-            submissionQueue.addPollIn(socket.intValue());
-            submissionQueue.submit();
+            submissionQueue().addPollIn(socket.intValue());
         }
 
         final void readComplete(int res) {
@@ -608,9 +598,7 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
                 long remoteAddressMemoryAddress = Buffer.memoryAddress(remoteAddressMemory);
 
                 socket.initAddress(address.address(), address.scopeId(), inetSocketAddress.getPort(), remoteAddressMemoryAddress);
-                final IOUringSubmissionQueue ioUringSubmissionQueue = submissionQueue();
-                ioUringSubmissionQueue.addConnect(socket.intValue(), remoteAddressMemoryAddress, SOCK_ADDR_LEN);
-                ioUringSubmissionQueue.submit();
+                submissionQueue().addConnect(socket.intValue(), remoteAddressMemoryAddress, SOCK_ADDR_LEN);
 
             } catch (Throwable t) {
                 closeIfClosed();

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
@@ -55,10 +55,8 @@ abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel imple
             final IOUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             allocHandle.attemptedBytesRead(1);
 
-            IOUringSubmissionQueue submissionQueue = submissionQueue();
             //Todo get network addresses
-            submissionQueue.addAccept(fd().intValue());
-            submissionQueue.submit();
+            submissionQueue().addAccept(fd().intValue());
         }
 
         protected void readComplete0(int res) {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
@@ -196,9 +196,7 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
         super.doRegister();
         if (active) {
             // Register for POLLRDHUP if this channel is already considered active.
-            IOUringSubmissionQueue submissionQueue = submissionQueue();
-            submissionQueue.addPollRdHup(fd().intValue());
-            submissionQueue.submit();
+            submissionQueue().addPollRdHup(fd().intValue());
         }
     }
 
@@ -216,15 +214,13 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
         protected void scheduleRead0() {
             final IOUringRecvByteAllocatorHandle allocHandle = recvBufAllocHandle();
             ByteBuf byteBuf = allocHandle.allocate(alloc());
-            IOUringSubmissionQueue submissionQueue = submissionQueue();
             allocHandle.attemptedBytesRead(byteBuf.writableBytes());
 
             assert readBuffer == null;
             readBuffer = byteBuf;
 
-            submissionQueue.addRead(socket.intValue(), byteBuf.memoryAddress(),
+            submissionQueue().addRead(socket.intValue(), byteBuf.memoryAddress(),
                     byteBuf.writerIndex(), byteBuf.capacity());
-            submissionQueue.submit();
         }
 
         @Override

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -27,8 +27,6 @@ final class IOUringCompletionQueue {
 
   private static final int CQE_SIZE = 16;
 
-  private static final int IORING_ENTER_GETEVENTS = 1;
-
   //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
   private final long kHeadAddress;
   private final long kTailAddress;
@@ -41,6 +39,9 @@ final class IOUringCompletionQueue {
   private final int ringSize;
   private final long ringAddress;
   private final int ringFd;
+  
+  private final int ringMask;
+  private int head;
 
   IOUringCompletionQueue(long kHeadAddress, long kTailAddress, long kringMaskAddress, long kringEntries,
       long kOverflowAddress, long completionQueueArrayAddress, int ringSize, long ringAddress, int ringFd) {
@@ -53,57 +54,49 @@ final class IOUringCompletionQueue {
     this.ringSize = ringSize;
     this.ringAddress = ringAddress;
     this.ringFd = ringFd;
+
+    this.ringMask = PlatformDependent.getInt(kringMaskAddress);
+  }
+
+  public boolean hasCompletions() {
+      return head != PlatformDependent.getInt(kTailAddress);
   }
 
   public int process(IOUringCompletionQueueCallback callback) {
+      int tail = PlatformDependent.getIntVolatile(kTailAddress);
+      if (head == tail) {
+          return 0;
+      }
       int i = 0;
       for (;;) {
-          long head = toUnsignedLong(PlatformDependent.getIntVolatile(kHeadAddress));
-          if (head != toUnsignedLong(PlatformDependent.getInt(kTailAddress))) {
-              long index = head & toUnsignedLong(PlatformDependent.getInt(kringMaskAddress));
-              long cqe = index * CQE_SIZE + completionQueueArrayAddress;
+          long index = head & ringMask;
+          long cqe = index * CQE_SIZE + completionQueueArrayAddress;
 
-              long udata = PlatformDependent.getLong(cqe + CQE_USER_DATA_FIELD);
-              int res = PlatformDependent.getInt(cqe + CQE_RES_FIELD);
-              long flags = toUnsignedLong(PlatformDependent.getInt(cqe + CQE_FLAGS_FIELD));
+          long udata = PlatformDependent.getLong(cqe + CQE_USER_DATA_FIELD);
+          int res = PlatformDependent.getInt(cqe + CQE_RES_FIELD);
+          int flags = PlatformDependent.getInt(cqe + CQE_FLAGS_FIELD);
 
-              //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
-              PlatformDependent.putIntOrdered(kHeadAddress, (int) (head + 1));
+          //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
+          PlatformDependent.putIntOrdered(kHeadAddress, ++head);
 
-              int fd = (int) (udata >> 32);
-              int opMask = (int) udata;
-              short op = (short) (opMask >> 16);
-              short mask = (short) opMask;
+          int fd = (int) (udata >> 32);
+          int opMask = (int) udata;
+          int op = (opMask >> 16) & 0xffff;
+          int mask = opMask & 0xffff;
 
-              i++;
-              if (!callback.handle(fd, res, flags, op, mask)) {
-                  break;
-              }
-          } else {
-              if (i == 0) {
-                  return -1;
-              }
-              return i;
+          i++;
+          if (!callback.handle(fd, res, flags, op, mask)) {
+              break;
+          }
+          if (head == tail && head == (tail = PlatformDependent.getIntVolatile(kTailAddress))) {
+              break;
           }
       }
       return i;
   }
 
   interface IOUringCompletionQueueCallback {
-      boolean handle(int fd, int res, long flags, int op, int mask);
-  }
-
-  public boolean ioUringWaitCqe() {
-    //IORING_ENTER_GETEVENTS -> wait until an event is completely processed
-    int ret = Native.ioUringEnter(ringFd, 0, 1, IORING_ENTER_GETEVENTS);
-    if (ret < 0) {
-        //Todo throw exception!
-        return false;
-    } else if (ret == 0) {
-        return true;
-    }
-    //Todo throw Exception!
-    return false;
+      boolean handle(int fd, int res, int flags, int op, int mask);
   }
 
   public long getKHeadAddress() {
@@ -136,10 +129,5 @@ final class IOUringCompletionQueue {
 
   public long getRingAddress() {
     return this.ringAddress;
-  }
-
-  //Todo Integer.toUnsignedLong -> maven checkstyle error
-  public static long toUnsignedLong(int x) {
-    return ((long) x) & 0xffffffffL;
   }
 }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -69,7 +69,7 @@ final class IOUringCompletionQueue {
       }
       int i = 0;
       for (;;) {
-          long index = ++head & ringMask;
+          long index = head & ringMask;
           long cqe = index * CQE_SIZE + completionQueueArrayAddress;
 
           long udata = PlatformDependent.getLong(cqe + CQE_USER_DATA_FIELD);
@@ -77,11 +77,11 @@ final class IOUringCompletionQueue {
           int flags = PlatformDependent.getInt(cqe + CQE_FLAGS_FIELD);
 
           //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
-          PlatformDependent.putIntOrdered(kHeadAddress, head);
+          PlatformDependent.putIntOrdered(kHeadAddress, ++head);
 
-          int fd = (int) (udata >> 32);
-          int opMask = (int) udata;
-          int op = (opMask >> 16) & 0xffff;
+          int fd = (int) (udata >>> 32);
+          int opMask = (int) (udata & 0xFFFFFFFFL);
+          int op = opMask >>> 16;
           int mask = opMask & 0xffff;
 
           i++;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -69,7 +69,7 @@ final class IOUringCompletionQueue {
       }
       int i = 0;
       for (;;) {
-          long index = head & ringMask;
+          long index = ++head & ringMask;
           long cqe = index * CQE_SIZE + completionQueueArrayAddress;
 
           long udata = PlatformDependent.getLong(cqe + CQE_USER_DATA_FIELD);
@@ -77,7 +77,7 @@ final class IOUringCompletionQueue {
           int flags = PlatformDependent.getInt(cqe + CQE_FLAGS_FIELD);
 
           //Ensure that the kernel only sees the new value of the head index after the CQEs have been read.
-          PlatformDependent.putIntOrdered(kHeadAddress, ++head);
+          PlatformDependent.putIntOrdered(kHeadAddress, head);
 
           int fd = (int) (udata >> 32);
           int opMask = (int) udata;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -119,7 +119,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
 
         // Lets add the eventfd related events before starting to do any real work.
         eventfdSqe = submissionQueue.reserveSqe(Native.IORING_OP_READ, 0, eventfd.intValue(), efdReadBuf, 8, 0);
-        submissionQueue.addReservedSqe(eventfdSqe);
+        submissionQueue.enqueueReservedSqe(eventfdSqe);
 
         for (;;) {
             for (;;) {
@@ -181,7 +181,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         if (op == Native.IORING_OP_READ || op == Native.IORING_OP_ACCEPT) {
             if (eventfd.intValue() == fd) {
                 pendingWakeup = false;
-                submissionQueue.addReservedSqe(eventfdSqe);
+                submissionQueue.enqueueReservedSqe(eventfdSqe);
             } else {
                 handleRead(fd, res);
             }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSubmissionQueueTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSubmissionQueueTest.java
@@ -25,9 +25,10 @@ public class IOUringSubmissionQueueTest {
         assertNotNull(completionQueue);
 
         int counter = 0;
-        while(!submissionQueue.addAccept(-1)) {
+        do {
+            submissionQueue.addAccept(-1);
             counter++;
-        }
+        } while (submissionQueue.count() != 0);
         assertEquals(8, counter);
     }
 }


### PR DESCRIPTION
Motivation

After reviewing the latest IOUring work I made a few changes to illustrate some of my prior review suggestions (plus some other things). This is not tested and I expect the changes will need some discussion/agreement!

Modifications

- Reserve an entry in the SQE array for the eventfd SQE so that we don't write it every time
- Don't pollin for eventfd, just read (I think this is ok due to the FAST_POLL magic)
- Combine submission/waiting, don't submit until either the queue is full or there's no more work to do (when entering wait)
- Rework event loop sequencing w.r.t. checking for tasks/completions
- Change some longs to back to ints where I don't think they need to be converted
- Track head/tail and masks (constant) as instance vars to avoid reading from the mapped buffer every time

Result

Hopefully further perf gains