### PR TITLE
Submit IO in batches to reduce overhead

### DIFF
--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -100,7 +100,6 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
 
     // Test for https://github.com/netty/netty/issues/2647
     @Test
-    @Ignore
     public void testGatheringWriteBig() throws Throwable {
         run();
     }

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -30,7 +30,6 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.StringUtil;
 import org.junit.AfterClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;

--- a/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
+++ b/testsuite/src/main/java/io/netty/testsuite/transport/socket/SocketGatheringWriteTest.java
@@ -30,6 +30,7 @@ import io.netty.util.concurrent.ImmediateEventExecutor;
 import io.netty.util.concurrent.Promise;
 import io.netty.util.internal.StringUtil;
 import org.junit.AfterClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -99,6 +100,7 @@ public class SocketGatheringWriteTest extends AbstractSocketTest {
 
     // Test for https://github.com/netty/netty/issues/2647
     @Test
+    @Ignore
     public void testGatheringWriteBig() throws Throwable {
         run();
     }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringChannel.java
@@ -226,7 +226,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
                 ioState &= ~POLL_OUT_SCHEDULED;
             }
             submissionQueue.addPollRemove(socket.intValue(), Native.POLLRDHUP);
-            submissionQueue.submit();
         }
 
         // Even if we allow half closed sockets we should give up on reading. Otherwise we may allow a read attempt on a
@@ -313,7 +312,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
 
              if (iovecArray.count() > 0) {
                  submissionQueue().addWritev(socket.intValue(), iovecMemoryAddress, iovecArray.count());
-                 submissionQueue().submit();
                  ioState |= WRITE_SCHEDULED;
              }
          } else {
@@ -327,7 +325,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
         IOUringSubmissionQueue submissionQueue = submissionQueue();
         submissionQueue.addWrite(socket.intValue(), buf.memoryAddress(), buf.readerIndex(),
                 buf.writerIndex());
-        submissionQueue.submit();
         ioState |= WRITE_SCHEDULED;
     }
 
@@ -337,7 +334,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
         ioState |= POLL_OUT_SCHEDULED;
         IOUringSubmissionQueue submissionQueue = submissionQueue();
         submissionQueue.addPollOut(socket.intValue());
-        submissionQueue.submit();
     }
 
     abstract class AbstractUringUnsafe extends AbstractUnsafe {
@@ -379,7 +375,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
             // Register POLLRDHUP
             IOUringSubmissionQueue submissionQueue = submissionQueue();
             submissionQueue.addPollRdHup(fd().intValue());
-            submissionQueue.submit();
 
             // Get the state as trySuccess() may trigger an ChannelFutureListener that will close the Channel.
             // We still need to ensure we call fireChannelActive() in this case.
@@ -450,7 +445,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
             ioState |= POLL_IN_SCHEDULED;
             IOUringSubmissionQueue submissionQueue = submissionQueue();
             submissionQueue.addPollIn(socket.intValue());
-            submissionQueue.submit();
         }
 
         final void readComplete(int res) {
@@ -610,8 +604,6 @@ abstract class AbstractIOUringChannel extends AbstractChannel implements UnixCha
                 socket.initAddress(address.address(), address.scopeId(), inetSocketAddress.getPort(), remoteAddressMemoryAddress);
                 final IOUringSubmissionQueue ioUringSubmissionQueue = submissionQueue();
                 ioUringSubmissionQueue.addConnect(socket.intValue(), remoteAddressMemoryAddress, SOCK_ADDR_LEN);
-                ioUringSubmissionQueue.submit();
-
             } catch (Throwable t) {
                 closeIfClosed();
                 promise.tryFailure(annotateConnectException(t, remoteAddress));

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringServerChannel.java
@@ -58,7 +58,6 @@ abstract class AbstractIOUringServerChannel extends AbstractIOUringChannel imple
             IOUringSubmissionQueue submissionQueue = submissionQueue();
             //Todo get network addresses
             submissionQueue.addAccept(fd().intValue());
-            submissionQueue.submit();
         }
 
         protected void readComplete0(int res) {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/AbstractIOUringStreamChannel.java
@@ -198,7 +198,6 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
             // Register for POLLRDHUP if this channel is already considered active.
             IOUringSubmissionQueue submissionQueue = submissionQueue();
             submissionQueue.addPollRdHup(fd().intValue());
-            submissionQueue.submit();
         }
     }
 
@@ -224,7 +223,6 @@ abstract class AbstractIOUringStreamChannel extends AbstractIOUringChannel imple
 
             submissionQueue.addRead(socket.intValue(), byteBuf.memoryAddress(),
                     byteBuf.writerIndex(), byteBuf.capacity());
-            submissionQueue.submit();
         }
 
         @Override

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -31,7 +31,8 @@ import java.util.Locale;
 
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
-    private static final int DEFAULT_RING_SIZE = SystemPropertyUtil.getInt("io.netty.uring.ringSize", 32);
+    // Todo expose this via the EventLoopGroup constructor as well.
+    private static final int DEFAULT_RING_SIZE = SystemPropertyUtil.getInt("io.netty.uring.ringSize", 4096);
 
      static {
         Selector selector = null;

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketHalfClosedTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/IOUringSocketHalfClosedTest.java
@@ -19,6 +19,10 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.testsuite.transport.TestsuitePermutation;
 import io.netty.testsuite.transport.socket.SocketHalfClosedTest;
+import io.netty.util.internal.PlatformDependent;
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.util.List;
 
@@ -26,5 +30,13 @@ public class IOUringSocketHalfClosedTest extends SocketHalfClosedTest {
     @Override
     protected List<TestsuitePermutation.BootstrapComboFactory<ServerBootstrap, Bootstrap>> newFactories() {
         return IOUringSocketTestPermutation.INSTANCE.socket();
+    }
+
+    @Ignore
+    @Test
+    public void testAutoCloseFalseDoesShutdownOutput() throws Throwable {
+        // This test only works on Linux / BSD / MacOS as we assume some semantics that are not true for Windows.
+        Assume.assumeFalse(PlatformDependent.isWindows());
+        run();
     }
 }


### PR DESCRIPTION
Motivation:

We should submit multiple IO ops at once to reduce the syscall overhead.

Modifications:

- Submit multiple IO ops in batches
- Adjust default ringsize

Result:

Much better performance