### PR TITLE
Lookup constants via JNI

### DIFF
--- a/transport-native-io_uring/src/main/c/netty_io_uring_native.c
+++ b/transport-native-io_uring/src/main/c/netty_io_uring_native.c
@@ -337,6 +337,14 @@ static jint netty_io_uring_sockCloexec(JNIEnv* env, jclass clazz) {
     return SOCK_CLOEXEC;
 }
 
+static jint netty_io_uring_etime(JNIEnv* env, jclass clazz) {
+    return ETIME;
+}
+
+static jint netty_io_uring_ecanceled(JNIEnv* env, jclass clazz) {
+    return ECANCELED;
+}
+
 static jint netty_io_uring_pollin(JNIEnv* env, jclass clazz) {
     return POLLIN;
 }
@@ -381,6 +389,10 @@ static jint netty_io_uring_ioringOpConnect(JNIEnv* env, jclass clazz) {
     return IORING_OP_CONNECT;
 }
 
+static jint netty_io_uring_ioringEnterGetevents(JNIEnv* env, jclass clazz) {
+    return IORING_ENTER_GETEVENTS;
+}
+
 static jint netty_io_uring_iosqeAsync(JNIEnv* env, jclass clazz) {
     return IOSQE_ASYNC;
 }
@@ -389,6 +401,8 @@ static jint netty_io_uring_iosqeAsync(JNIEnv* env, jclass clazz) {
 static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "sockNonblock", "()I", (void *) netty_io_uring_sockNonblock },
   { "sockCloexec", "()I", (void *) netty_io_uring_sockCloexec },
+  { "etime", "()I", (void *) netty_io_uring_etime },
+  { "ecanceled", "()I", (void *) netty_io_uring_ecanceled },
   { "pollin", "()I", (void *) netty_io_uring_pollin },
   { "pollout", "()I", (void *) netty_io_uring_pollout },
   { "pollrdhup", "()I", (void *) netty_io_uring_pollrdhup },
@@ -400,7 +414,9 @@ static const JNINativeMethod statically_referenced_fixed_method_table[] = {
   { "ioringOpRead", "()I", (void *) netty_io_uring_ioringOpRead },
   { "ioringOpWrite", "()I", (void *) netty_io_uring_ioringOpWrite },
   { "ioringOpConnect", "()I", (void *) netty_io_uring_ioringOpConnect },
+  { "ioringEnterGetevents", "()I", (void *) netty_io_uring_ioringEnterGetevents },
   { "iosqeAsync", "()I", (void *) netty_io_uring_iosqeAsync }
+
 };
 static const jint statically_referenced_fixed_method_table_size = sizeof(statically_referenced_fixed_method_table) / sizeof(statically_referenced_fixed_method_table[0]);
 

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringCompletionQueue.java
@@ -27,8 +27,6 @@ final class IOUringCompletionQueue {
 
   private static final int CQE_SIZE = 16;
 
-  private static final int IORING_ENTER_GETEVENTS = 1;
-
   //these unsigned integer pointers(shared with the kernel) will be changed by the kernel
   private final long kHeadAddress;
   private final long kTailAddress;
@@ -95,7 +93,7 @@ final class IOUringCompletionQueue {
 
   public boolean ioUringWaitCqe() {
     //IORING_ENTER_GETEVENTS -> wait until an event is completely processed
-    int ret = Native.ioUringEnter(ringFd, 0, 1, IORING_ENTER_GETEVENTS);
+    int ret = Native.ioUringEnter(ringFd, 0, 1, Native.IORING_ENTER_GETEVENTS);
     if (ret < 0) {
         //Todo throw exception!
         return false;

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringEventLoop.java
@@ -34,9 +34,6 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
                                                            IOUringCompletionQueue.IOUringCompletionQueueCallback {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(IOUringEventLoop.class);
 
-    private static final long ETIME = -62;
-    static final long ECANCELED = -125;
-
     private final IntObjectMap<AbstractIOUringChannel> channels = new IntObjectHashMap<AbstractIOUringChannel>(4096);
     private final RingBuffer ringBuffer;
 
@@ -176,7 +173,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         } else if (op == Native.IORING_OP_WRITEV || op == Native.IORING_OP_WRITE) {
             handleWrite(fd, res);
         } else if (op == Native.IORING_OP_POLL_ADD) {
-            if (res == ECANCELED) {
+            if (res == Native.ERRNO_ECANCELED_NEGATIVE) {
                 logger.trace("IORING_POLL_ADD cancelled");
                 return true;
             }
@@ -195,7 +192,7 @@ final class IOUringEventLoop extends SingleThreadEventLoop implements
         } else if (op == Native.IORING_OP_CONNECT) {
             handleConnect(fd, res);
         } else if (op == Native.IORING_OP_TIMEOUT) {
-            if (res == ETIME) {
+            if (res == Native.ERRNO_ETIME_NEGATIVE) {
                 prevDeadlineNanos = NONE;
             }
         }

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/Native.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.nio.channels.Selector;
 import java.util.Locale;
 
-
 final class Native {
     private static final InternalLogger logger = InternalLoggerFactory.getInstance(Native.class);
     // Todo expose this via the EventLoopGroup constructor as well.
@@ -68,6 +67,8 @@ final class Native {
     static final int POLLIN = NativeStaticallyReferencedJniMethods.pollin();
     static final int POLLOUT = NativeStaticallyReferencedJniMethods.pollout();
     static final int POLLRDHUP = NativeStaticallyReferencedJniMethods.pollrdhup();
+    static final int ERRNO_ECANCELED_NEGATIVE = -NativeStaticallyReferencedJniMethods.ecanceled();
+    static final int ERRNO_ETIME_NEGATIVE = -NativeStaticallyReferencedJniMethods.etime();
 
     static final int IORING_OP_POLL_ADD = NativeStaticallyReferencedJniMethods.ioringOpPollAdd();
     static final int IORING_OP_TIMEOUT = NativeStaticallyReferencedJniMethods.ioringOpTimeout();
@@ -77,6 +78,7 @@ final class Native {
     static final int IORING_OP_POLL_REMOVE = NativeStaticallyReferencedJniMethods.ioringOpPollRemove();
     static final int IORING_OP_CONNECT = NativeStaticallyReferencedJniMethods.ioringOpConnect();
     static final int IORING_OP_WRITEV = NativeStaticallyReferencedJniMethods.ioringOpWritev();
+    static final int IORING_ENTER_GETEVENTS = NativeStaticallyReferencedJniMethods.ioringEnterGetevents();
     static final int IOSQE_ASYNC = NativeStaticallyReferencedJniMethods.iosqeAsync();
 
     public static RingBuffer createRingBuffer(int ringSize) {

--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/NativeStaticallyReferencedJniMethods.java
@@ -32,6 +32,8 @@ final class NativeStaticallyReferencedJniMethods {
 
     static native int sockNonblock();
     static native int sockCloexec();
+    static native int etime();
+    static native int ecanceled();
     static native int pollin();
     static native int pollout();
     static native int pollrdhup();
@@ -44,5 +46,6 @@ final class NativeStaticallyReferencedJniMethods {
     static native int ioringOpRead();
     static native int ioringOpWrite();
     static native int ioringOpConnect();
+    static native int ioringEnterGetevents();
     static native int iosqeAsync();
 }

--- a/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
+++ b/transport-native-io_uring/src/test/java/io/netty/channel/uring/NativeTest.java
@@ -239,7 +239,7 @@ public class NativeTest {
                 @Override
                 public boolean handle(int fd, int res, long flags, int op, int mask) {
                     if (op == Native.IORING_OP_POLL_ADD) {
-                        assertEquals(IOUringEventLoop.ECANCELED, res);
+                        assertEquals(Native.ERRNO_ECANCELED_NEGATIVE, res);
                     } else if (op == Native.IORING_OP_POLL_REMOVE) {
                         assertEquals(0, res);
                     } else {


### PR DESCRIPTION
Motivation:

We should better use JNI to lookup constants so we are sure we not mess
things up

Modifications:

Use JNI calls to lookup constants once

Result:

Less error prone code