### PR TITLE
Add workaround for current kernel bug related to WRITEV and IOSEQ_ASYNC

### DIFF
--- a/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
+++ b/transport-native-io_uring/src/main/java/io/netty/channel/uring/IOUringSubmissionQueue.java
@@ -137,7 +137,10 @@ final class IOUringSubmissionQueue {
         }
 
         // TODO: Make it configurable if we should use this flag or not.
-        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD, (byte) Native.IOSQE_ASYNC);
+        PlatformDependent.putByte(sqe + SQE_FLAGS_FIELD,
+                // Workaround for a kernel bug:
+                // See https://lore.kernel.org/io-uring/6428c1ee0234105d18c5e3e88aa00c57@nickhill.org/T/#t
+                (byte) (op != Native.IORING_OP_WRITEV ? Native.IOSQE_ASYNC : 0));
 
         // pad field array -> all fields should be zero
         long offsetIndex = 0;


### PR DESCRIPTION
Motivation:

There is currently a bug in the kernel that let WRITEV sometimes fail
when IOSEQ_ASYNC is enabled

Modifications:

Don't use IOSEQ_ASYNC for WRITEV for now

Result:

Tests pass